### PR TITLE
Korrektur der Zeitverschiebung nach RFC-3339

### DIFF
--- a/evcc_message
+++ b/evcc_message
@@ -2,7 +2,16 @@
 
 ip=localhost:7070
 log="/tmp/evcc_targettime.log"
+set_targettime="06:00:00"
+
 now=$(date)
+rfc3339="$(date --rfc-3339=seconds)"
+diff="${rfc3339:20:2}"
+hour="${set_targettime:0:2}"
+calc=$(($hour - $diff))
+t1="$(printf "%02d" "$calc")"
+t2="${set_targettime:2:6}"
+delta=$(( $(date +%s) - $(date -d "$(date +"%Y-%m-%d") $set_targettime" +%s) ))
 
 echo "message received: $1 - $now" >> $log
 if [[ "$2" == *"connected, mode:pv"* ]] # guest and car
@@ -10,14 +19,17 @@ then
 	week_day=$(date +%w) #get the week day as a number from 0 to 6 starting with 0 as Sunday
 	if [[ $week_day -ge 0 && $week_day -le 4 ]] # from monday to thursday
 	then
-		targettime=$(date -d "+1 day" -u +"%Y-%m-%d")T06:00:00Z
+		if [[ $delta -lt -300 ]]
+		then
+			targettime=$(date +"%Y-%m-%d")T${t1}${t2}Z
+		else
+			targettime=$(date -d "+1 day" +"%Y-%m-%d")T${t1}${t2}Z
+		fi
 	else
-		targettime=$(date -d "+2 day" -u +"%Y-%m-%d")T07:00:00Z
+		targettime=$(date -d "+2 day" +"%Y-%m-%d")T${t1}${t2}Z
 	fi
 	curl -X POST http://$ip/api/loadpoints/1/target/time/$targettime > /dev/null
 	echo "Setting targettime: " $targettime >> $log
 else
 	echo "Wrong message: " $2 >> $log
 fi
-
-


### PR DESCRIPTION
Moin,
vielen Dank für das Script, was grundsätzlich wunderbar funktioniert. Mir ist allerdings aufgefallen, dass targetime mit dem date-flag -u (UTC) eine Differenz von aktuell 1 Stunde hat. Das führt dazu, dass z.B. am 02.02.2023 um 00:25 Uhr das Script von einem Datum 01.02.2023 um 23:25 Uhr ausgeht. Daher habe ich das Argument -u entfernt.

Des Weiteren wird in der EVCC API die Targettime nach RFC-3339 berechnet. Bedeutet aktuell eine Verschiebung von 1 Stunde, bei Sommerzeit von 2 Stunden. Wenn man also im Script bisher 06:00:00 Uhr als Targettime vorgeben hat, wurde 7:00 Uhr gesetzt, im Sommer wäre es 8:00 Uhr.

Daher gebe ich die feste Uhrzeit in Zeile 5 vor und rufe die aktuell gültige Zeitverschiebung ab, berechne die Differenz und ziehe diese von der gewollten Zeit ab. Damit gewährleiste ich immer das Setzen der vorgegebenen Zielzeit unabhängig von Sommer- oder Winterzeit.

Dann habe ich noch eine Bedingung ergänzt, wenn der Wagen nach Mitternacht eingestöpselt wird, würde erst am nächsten Tag geladen. Daher prüfe ich in Zeile 14, ob wir noch vor der Zielzeit liegen. Das wird dann in Zeile 22 (aktuell mit 300 Sekunden = 5 Minuten) berücksichtigt.